### PR TITLE
typo in zookeeper

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -20,7 +20,7 @@ import Link from "./Link.astro";
         "terraforming your cloud",
         "can't reach consensus",
         "stuck on a raft",
-        "selfie with the zookeper",
+        "selfie with the zookeeper",
         "I am TLS (The Laughing Stock)",
         "docker? I barely know her",
         "use vim btw",


### PR DESCRIPTION
- chore: foodbox url
- chore: https://
- feat: caret for hover
- fix: typo
